### PR TITLE
Always print newline after status message.

### DIFF
--- a/check_xsiactions
+++ b/check_xsiactions
@@ -106,7 +106,7 @@ sub nagios_exit {
 		printf($nagios_exit_message);
 	}
 	
-	print("\n") if $verbose;
+	print("\n");
 	exit $nagios_exit_code;
 
 }

--- a/check_xsievents
+++ b/check_xsievents
@@ -161,7 +161,7 @@ sub nagios_exit {
 		printf($nagios_exit_message);
 	}
 	
-	print("\n") if $verbose;
+	print("\n");
 	exit $nagios_exit_code;
 
 }


### PR DESCRIPTION
The newline should always be used after the status message, without it you get:
```
foo@bar:~$ perl /tmp/check_xsievents -u user@domain.tld -p password -H example.com
XSIEvents OK - 0.214600 seconds response time|time=0.214803s;2.000000;30.000000;0.0;31.0foo@bar:~$
```
Instead of:
```
foo@bar:~$ perl /tmp/check_xsievents -u user@domain.tld -p password -H example.com
XSIEvents OK - 0.214600 seconds response time|time=0.214803s;2.000000;30.000000;0.0;31.0
foo@bar:~$
```